### PR TITLE
Cleaner lag rescaling

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -18,7 +18,7 @@ rule diagnostics:
             "pipeline/out/lag/plot_{scaling_factor}.png",
             scaling_factor=config["empirical_lag"]["scaling_factors"],
         )
-    
+
 
 rule simulate_rt:
     output:

--- a/Snakefile
+++ b/Snakefile
@@ -12,6 +12,14 @@ rule all:
             rep=np.arange(config["simulations"]["n_rep"])
         )
 
+rule diagnostics:
+    input:
+        expand(
+            "pipeline/out/lag/plot_{scaling_factor}.png",
+            scaling_factor=config["empirical_lag"]["scaling_factors"],
+        )
+    
+
 rule simulate_rt:
     output:
         "pipeline/out/rt/{scenario}.txt",
@@ -39,18 +47,28 @@ rule generate_prevalence:
     shell:
         "python3 -m pipeline.generate_prevalence --config pipeline/config.json --infile {input} --outfile {output}"
 
-rule fit_lags:
+rule fit_lag:
     output:
-        "pipeline/out/lags/{scaling_factor}.json",
+        "pipeline/out/lag/fit.json",
 
     shell:
-        "python3 -m pipeline.fit_lags --config pipeline/config.json --scaling_factor {wildcards.scaling_factor} --outfile {output}"
+        "python3 -m pipeline.fit_lag --config pipeline/config.json --outfile {output}"
+
+rule plot_lag_diagnostic:
+    input:
+        "pipeline/out/lag/fit.json",
+
+    output:
+        "pipeline/out/lag/plot_{scaling_factor}.png",
+
+    shell:
+        "python3 -m pipeline.plot_lag --config pipeline/config.json --scaling_factor {wildcards.scaling_factor} --infile {input} --outfile {output}"
 
 rule simulate_data:
     input:
         "pipeline/out/infections/incidence_{scenario}_{i0}.txt",
         "pipeline/out/infections/prevalence_{scenario}_{i0}.txt",
-        "pipeline/out/lags/{scaling_factor}.json",
+        "pipeline/out/lag/fit.json",
 
     output:
         "pipeline/out/coalescent/{scenario}_{i0}_{scaling_factor}_{rep}.json"

--- a/pipeline/plot_lag.py
+++ b/pipeline/plot_lag.py
@@ -1,0 +1,64 @@
+import json
+
+import numpy as np
+
+import matplotlib.pyplot as plt
+
+from pipeline.fit_lag import BHSQI, get_empirical_lag
+from pipeline.utils import construct_seed, parser, read_config
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+
+    config = read_config(args.config)
+
+    with open(args.infile[0], "r") as file:
+        lag_params = json.load(file)
+
+    empirical_lags = get_empirical_lag(config)
+    approx_lag_dist = BHSQI(knots=np.array(lag_params["knots"]),coef=np.array(lag_params["coef"]))
+    lag_scales = config["empirical_lag"]["scaling_factors"]
+
+    q_vec = np.arange(1., 2499.) / 2500.
+
+    scale = float(args.scaling_factor)
+    rng = np.random.default_rng(construct_seed(config["seed"], scenario=None, i0=None, scaling_factor=args.scaling_factor, rep=None))
+
+    approx_samples = approx_lag_dist.draw(size=100000, scale=scale, rng=rng)
+
+    fig, axs = plt.subplots(2, 2, figsize=(12,12))
+
+    # Approximate PDF (meaningful range)
+    t_pdf = np.linspace(0., np.quantile(empirical_lags * scale, np.array([0.95])), 2500)
+    axs[0,0].plot(t_pdf, approx_lag_dist.pdf(t_pdf, scale=scale))
+    axs[0,0].set_ylabel("PDF")
+
+    # Approximate CDF (whole range)
+    t_cdf = np.linspace(0., approx_lag_dist.xmax, 2500)
+    axs[1,0].plot(t_cdf, approx_lag_dist.cdf(t_cdf, scale=scale))
+    axs[1,0].set_ylabel("CDF")
+    axs[1,0].set_xlabel("Time (in days)")
+
+    # QQ plot of approximation vs empirical distribution
+    approx_quants = np.array([
+        approx_lag_dist.quantile_function(p, scale=scale)
+        for p in q_vec
+    ])
+    observed_quants = np.quantile(empirical_lags * scale, q_vec)
+    axs[0,1].plot(observed_quants, approx_quants)
+    axs[0,1].plot(
+        observed_quants, observed_quants, ls="--"
+    )  # a 1:1 line for comparison
+    axs[0,1].set_ylabel("Approximated quantiles")
+    axs[0,1].set_xlabel("Empirical quantiles")
+
+    # Samples look like approximation they should be draws from
+    approx_sample_quants = np.quantile(approx_samples, q_vec)
+
+    axs[1,1].plot(approx_quants, approx_sample_quants)
+    axs[1,1].plot(approx_quants, approx_quants, ls="--")  # a 1:1 line for comparison
+    axs[1,1].set_ylabel("Approximated quantiles")
+    axs[1,1].set_xlabel("Approximation sample quantiles")
+    
+    plt.savefig(args.outfile)

--- a/pipeline/plot_lag.py
+++ b/pipeline/plot_lag.py
@@ -1,12 +1,10 @@
 import json
 
-import numpy as np
-
 import matplotlib.pyplot as plt
+import numpy as np
 
 from pipeline.fit_lag import BHSQI, get_empirical_lag
 from pipeline.utils import construct_seed, parser, read_config
-
 
 if __name__ == "__main__":
     args = parser.parse_args()
@@ -17,48 +15,61 @@ if __name__ == "__main__":
         lag_params = json.load(file)
 
     empirical_lags = get_empirical_lag(config)
-    approx_lag_dist = BHSQI(knots=np.array(lag_params["knots"]),coef=np.array(lag_params["coef"]))
+    approx_lag_dist = BHSQI(
+        knots=np.array(lag_params["knots"]), coef=np.array(lag_params["coef"])
+    )
     lag_scales = config["empirical_lag"]["scaling_factors"]
 
-    q_vec = np.arange(1., 2499.) / 2500.
+    q_vec = np.arange(1.0, 2499.0) / 2500.0
 
     scale = float(args.scaling_factor)
-    rng = np.random.default_rng(construct_seed(config["seed"], scenario=None, i0=None, scaling_factor=args.scaling_factor, rep=None))
+    rng = np.random.default_rng(
+        construct_seed(
+            config["seed"],
+            scenario=None,
+            i0=None,
+            scaling_factor=args.scaling_factor,
+            rep=None,
+        )
+    )
 
     approx_samples = approx_lag_dist.draw(size=100000, scale=scale, rng=rng)
 
-    fig, axs = plt.subplots(2, 2, figsize=(12,12))
+    fig, axs = plt.subplots(2, 2, figsize=(12, 12))
 
     # Approximate PDF (meaningful range)
-    t_pdf = np.linspace(0., np.quantile(empirical_lags * scale, np.array([0.95])), 2500)
-    axs[0,0].plot(t_pdf, approx_lag_dist.pdf(t_pdf, scale=scale))
-    axs[0,0].set_ylabel("PDF")
+    t_pdf = np.linspace(
+        0.0, np.quantile(empirical_lags * scale, np.array([0.95])), 2500
+    )
+    axs[0, 0].plot(t_pdf, approx_lag_dist.pdf(t_pdf, scale=scale))
+    axs[0, 0].set_ylabel("PDF")
 
     # Approximate CDF (whole range)
-    t_cdf = np.linspace(0., approx_lag_dist.xmax, 2500)
-    axs[1,0].plot(t_cdf, approx_lag_dist.cdf(t_cdf, scale=scale))
-    axs[1,0].set_ylabel("CDF")
-    axs[1,0].set_xlabel("Time (in days)")
+    t_cdf = np.linspace(0.0, approx_lag_dist.xmax, 2500)
+    axs[1, 0].plot(t_cdf, approx_lag_dist.cdf(t_cdf, scale=scale))
+    axs[1, 0].set_ylabel("CDF")
+    axs[1, 0].set_xlabel("Time (in days)")
 
     # QQ plot of approximation vs empirical distribution
-    approx_quants = np.array([
-        approx_lag_dist.quantile_function(p, scale=scale)
-        for p in q_vec
-    ])
+    approx_quants = np.array(
+        [approx_lag_dist.quantile_function(p, scale=scale) for p in q_vec]
+    )
     observed_quants = np.quantile(empirical_lags * scale, q_vec)
-    axs[0,1].plot(observed_quants, approx_quants)
-    axs[0,1].plot(
+    axs[0, 1].plot(observed_quants, approx_quants)
+    axs[0, 1].plot(
         observed_quants, observed_quants, ls="--"
     )  # a 1:1 line for comparison
-    axs[0,1].set_ylabel("Approximated quantiles")
-    axs[0,1].set_xlabel("Empirical quantiles")
+    axs[0, 1].set_ylabel("Approximated quantiles")
+    axs[0, 1].set_xlabel("Empirical quantiles")
 
     # Samples look like approximation they should be draws from
     approx_sample_quants = np.quantile(approx_samples, q_vec)
 
-    axs[1,1].plot(approx_quants, approx_sample_quants)
-    axs[1,1].plot(approx_quants, approx_quants, ls="--")  # a 1:1 line for comparison
-    axs[1,1].set_ylabel("Approximated quantiles")
-    axs[1,1].set_xlabel("Approximation sample quantiles")
-    
+    axs[1, 1].plot(approx_quants, approx_sample_quants)
+    axs[1, 1].plot(
+        approx_quants, approx_quants, ls="--"
+    )  # a 1:1 line for comparison
+    axs[1, 1].set_ylabel("Approximated quantiles")
+    axs[1, 1].set_xlabel("Approximation sample quantiles")
+
     plt.savefig(args.outfile)

--- a/pipeline/simulate_data.py
+++ b/pipeline/simulate_data.py
@@ -3,28 +3,8 @@ import json
 import numpy as np
 
 from lag.models import RenewalCoalescentModel
-from pipeline.fit_lags import BHSQI
+from pipeline.fit_lag import BHSQI
 from pipeline.utils import construct_seed, parser, read_config
-
-
-class LagSampler:
-    """
-    Wrapper for BHSQI that allows 0 lag.
-    """
-
-    def __init__(self, list_params):
-        if list_params == {}:
-            self.bhsqi = None
-        else:
-            self.bhsqi = BHSQI(
-                np.array(list_params["knots"]), np.array(list_params["coef"])
-            )
-
-    def draw(self, size: int, rng: np.random.Generator) -> np.typing.NDArray:
-        if self.bhsqi is None:
-            return np.array([0.0] * size)
-        else:
-            return self.bhsqi.draw(size=size, rng=rng)
 
 
 def simulate_sampling_times(
@@ -74,7 +54,7 @@ if __name__ == "__main__":
     with open(args.infile[2], "r") as file:
         lag_params = json.load(file)
 
-    lag_sampler = LagSampler(lag_params)
+    lag_dist = BHSQI(**lag_params)
 
     samp_times = simulate_sampling_times(
         config["simulations"]["sampling"]["weekday_effect"],
@@ -88,8 +68,8 @@ if __name__ == "__main__":
         backwards_incidence,
         backwards_prevalence,
     )
-    lags = lag_sampler.draw(
-        config["simulations"]["sampling"]["n_samples"], rng
+    lags = lag_dist.draw(
+        size=config["simulations"]["sampling"]["n_samples"], scale=lag_scale, rng=rng
     )
     data = unlagged_data.as_of(as_of=0.0, lags=lags)
 

--- a/pipeline/simulate_data.py
+++ b/pipeline/simulate_data.py
@@ -69,7 +69,9 @@ if __name__ == "__main__":
         backwards_prevalence,
     )
     lags = lag_dist.draw(
-        size=config["simulations"]["sampling"]["n_samples"], scale=lag_scale, rng=rng
+        size=config["simulations"]["sampling"]["n_samples"],
+        scale=lag_scale,
+        rng=rng,
     )
     data = unlagged_data.as_of(as_of=0.0, lags=lags)
 


### PR DESCRIPTION
This PR re-casts `pipeline.BHSQI` as a location-scale transformable distribution. This streamlines the pipeline (requiring only fitting and storing one set of `pipeline.BHSQI` parameters) and makes the code more explicit about what the rescaling is and how it works. It also makes it much easier to plot the scaled approximations, so we can see what the scaling factors imply and check that everything is working acceptably.