### PR TITLE
Error on missing inputs

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -4,6 +4,8 @@ import os
 configfile: "pipeline/config.json"
 
 scenario_list = glob_wildcards("pipeline/input/rt/{scenario}.txt").scenario
+if not scenario_list:
+    raise RuntimeError("There are no Rt scenarios.")
 
 rule all:
     input:
@@ -99,8 +101,11 @@ rule plot_coalescent_math_diagnostics:
         "python3 -m pipeline.plot_coalescent_math --config pipeline/config.json --infile {input} --outfile {output}"
 
 rule fit_lag:
+    input:
+        "pipeline/input/metadata.tsv"
+
     output:
-        "pipeline/output/lag/fit.json",
+        "pipeline/output/lag/fit.json"
 
     shell:
         "python3 -m pipeline.fit_lag --config pipeline/config.json --outfile {output}"

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -93,6 +93,7 @@ The pipeline requires two inputs:
 - $R_t$ time series, taken to be values of a weekly piecewise-constant function, in `pipeline/input/rt`, as plain text with one line per week (forward in time).
 
 Running `poetry run sh pipeline/setup.sh` will result in the requisite Nextstrain data being downloaded and uncompressed as well as the generation of three suitable $R_t$ time series.
+This requires [`zstd`](https://github.com/facebook/zstd), available for example on Ubuntu via `apt install zstd`.
 
 With these inputs in place, run the pipeline via `poetry run snakemake -j1` (this flag keeps snakemake from conflicting with NumPyro and polars on core and memory usage).
 

--- a/pipeline/setup.sh
+++ b/pipeline/setup.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+mkdir -p pipeline/input/rt/
+
 curl https://data.nextstrain.org/files/ncov/open/metadata.tsv.zst -o pipeline/input/metadata.tsv.zst
 unzstd pipeline/input/metadata.tsv.zst -o pipeline/input/metadata.tsv
 


### PR DESCRIPTION
The pipeline was not set up to fail loudly absent the required inputs. This PR amends this oversight.