### PR TITLE
Simplify renewal/coalescent handoff

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -20,25 +20,25 @@ rule all:
 rule diagnostics:
     input:
         expand(
-            "pipeline/output/coalescent/{scenario}_{i0}.png",
+            "pipeline/output/diagnostics/coalescent/{scenario}_{i0}.png",
             scenario=scenario_list,
             i0=config["simulations"]["i0"],
         ),
         expand(
-            "pipeline/output/infections/{scenario}_{i0}.png",
+            "pipeline/output/diagnostics/infections/{scenario}_{i0}.png",
             scenario=scenario_list,
             i0=config["simulations"]["i0"],
         ),
         expand(
-            "pipeline/output/rt/{scenario}.png",
+            "pipeline/output/diagnostics/rt/{scenario}.png",
             scenario=scenario_list,
         ),
         expand(
-            "pipeline/output/lag/{scaling_factor}.png",
+            "pipeline/output/diagnostics/lag/{scaling_factor}.png",
             scaling_factor=config["empirical_lag"]["scaling_factors"],
         ),
         expand(
-            "pipeline/output/coalescent/{scenario}_{i0}_{scaling_factor}.png",
+            "pipeline/output/diagnostics/coalescent/{scenario}_{i0}_{scaling_factor}.png",
             scenario=scenario_list,
             i0=config["simulations"]["i0"],
             scaling_factor=config["empirical_lag"]["scaling_factors"],
@@ -65,7 +65,7 @@ rule plot_rt_diagnostic:
         "pipeline/input/rt/{scenario}.txt"
 
     output:
-        "pipeline/output/rt/{scenario}.png",
+        "pipeline/output/diagnostics/rt/{scenario}.png",
 
     shell:
         "python3 -m pipeline.plot_rt --config pipeline/config.json --scenario {wildcards.scenario} --infile {input} --outfile {output}"
@@ -85,7 +85,7 @@ rule plot_infection_diagnostics:
         "pipeline/output/infections/{scenario}_{i0}.json"
 
     output:
-        "pipeline/output/infections/{scenario}_{i0}.png"
+        "pipeline/output/diagnostics/infections/{scenario}_{i0}.png"
 
     shell:
         "python3 -m pipeline.plot_infections --config pipeline/config.json --infile {input} --outfile {output}"
@@ -95,7 +95,7 @@ rule plot_coalescent_math_diagnostics:
         "pipeline/output/infections/{scenario}_{i0}.json"
 
     output:
-        "pipeline/output/coalescent/{scenario}_{i0}.png"
+        "pipeline/output/diagnostics/coalescent/{scenario}_{i0}.png"
 
     shell:
         "python3 -m pipeline.plot_coalescent_math --config pipeline/config.json --infile {input} --outfile {output}"
@@ -116,7 +116,7 @@ rule plot_lag_diagnostic:
         "pipeline/output/rt/hash.json",
 
     output:
-        "pipeline/output/lag/{scaling_factor}.png",
+        "pipeline/output/diagnostics/lag/{scaling_factor}.png",
 
     shell:
         "python3 -m pipeline.plot_lag --config pipeline/config.json --scaling_factor {wildcards.scaling_factor} --infile {input} --outfile {output}"
@@ -143,7 +143,7 @@ rule plot_coalescent_diagnostic:
         )
 
     output:
-        "pipeline/output/coalescent/{scenario}_{i0}_{scaling_factor}.png"
+        "pipeline/output/diagnostics/coalescent/{scenario}_{i0}_{scaling_factor}.png"
 
     shell:
         "python3 -m pipeline.plot_coalescent_rate --config pipeline/config.json --scenario {wildcards.scenario} --i0 {wildcards.i0} --scaling_factor {wildcards.scaling_factor} --infile {input} --outfile {output}"

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -9,6 +9,28 @@
   publisher={Oxford University Press}
 }
 
+@article{charlesworth2009effective,
+  title={Effective population size and patterns of molecular evolution and variation},
+  author={Charlesworth, Brian},
+  journal={Nature Reviews Genetics},
+  volume={10},
+  number={3},
+  pages={195--205},
+  year={2009},
+  publisher={Nature Publishing Group UK London}
+}
+
+@article{engen2005effective,
+  title={Effective size of a fluctuating age-structured population},
+  author={Engen, Steinar and Lande, Russell and Saether, Bernt-Erik},
+  journal={Genetics},
+  volume={170},
+  number={2},
+  pages={941--954},
+  year={2005},
+  publisher={Oxford University Press}
+}
+
 @article{frost2010viral,
   title={Viral phylodynamics and the search for an `effective number of infections'},
   author={Frost, Simon DW and Volz, Erik M},
@@ -31,6 +53,28 @@
   publisher={Oxford University Press}
 }
 
+@article{green2022inferring,
+  title={Inferring the reproduction number using the renewal equation in heterogeneous epidemics},
+  author={Green, William D and Ferguson, Neil M and Cori, Anne},
+  journal={Journal of The Royal Society Interface},
+  volume={19},
+  number={188},
+  pages={20210429},
+  year={2022},
+  publisher={The Royal Society}
+}
+
+@article{hill1979note,
+  title={A note on effective population size with overlapping generations},
+  author={Hill, William G},
+  journal={Genetics},
+  volume={92},
+  number={1},
+  pages={317--322},
+  year={1979},
+  publisher={Oxford University Press}
+}
+
 @article{kingman1982coalescent,
   title={The coalescent},
   author={Kingman, John Frank Charles},
@@ -40,4 +84,34 @@
   pages={235--248},
   year={1982},
   publisher={Elsevier}
+}
+
+@article{palacios2013gaussian,
+  title={Gaussian process-based Bayesian nonparametric inference of population size trajectories from gene genealogies},
+  author={Palacios, Julia A and Minin, Vladimir N},
+  journal={Biometrics},
+  volume={69},
+  number={1},
+  pages={8--18},
+  year={2013},
+  publisher={Oxford University Press}
+}
+
+@article{volz2009phylodynamics,
+  title={Phylodynamics of infectious disease epidemics},
+  author={Volz, Erik M and Kosakovsky Pond, Sergei L and Ward, Melissa J and Leigh Brown, Andrew J and Frost, Simon DW},
+  journal={Genetics},
+  volume={183},
+  number={4},
+  pages={1421--1430},
+  year={2009},
+  publisher={Oxford University Press}
+}
+
+@book{wakely2009,
+  title={Coalescent theory: an introduction},
+  author={John Wakeley},
+  year={2009},
+  publisher={W. H. Freeman},
+  address={New York}
 }

--- a/lag/models.py
+++ b/lag/models.py
@@ -89,7 +89,12 @@ class RenewalCoalescentModel(RtModel):
     def approx_coalescent_rate(
         prevalence, force_of_infection, n_active_choose_2
     ):
-        return n_active_choose_2 * 2.0 * force_of_infection / prevalence
+        return (
+            n_active_choose_2
+            * 2.0
+            * force_of_infection
+            / jnp.pow(prevalence, 2.0)
+        )
 
     @staticmethod
     def grid_helper(
@@ -238,14 +243,12 @@ class RenewalCoalescentModel(RtModel):
         """
         Unifies sampling and rate shift times for simulation.
         """
-        assert rate_shift_times.shape[0] == force_of_infection.shape[0] - 1, (
-            f"There are {rate_shift_times.shape[0]} rate shift times, expected {rate_shift_times.shape[0] + 1} `force_of_infection` and `prevalence entries`."
-        )
+        assert (
+            rate_shift_times.shape[0] == force_of_infection.shape[0] - 1
+        ), f"There are {rate_shift_times.shape[0]} rate shift times, expected {rate_shift_times.shape[0] + 1} `force_of_infection` and `prevalence entries`."
         assert (
             force_of_infection.shape[0] == approx_squared_prevalence.shape[0]
-        ), (
-            f"Provided force_of_infection is length {force_of_infection.shape[0]} while provided prevalence is length {approx_squared_prevalence.shape[0]}"
-        )
+        ), f"Provided force_of_infection is length {force_of_infection.shape[0]} while provided prevalence is length {approx_squared_prevalence.shape[0]}"
         rate_times = np.concat(
             (
                 np.sort(rate_shift_times),

--- a/pipeline/config.json
+++ b/pipeline/config.json
@@ -23,7 +23,7 @@
             "n_samples" : 2000,
             "n_sampled_weeks" : 12
         },
-        "n_rep" : 3,
+        "n_rep" : 50,
         "i0" : [1000]
     },
     "renewal" : {

--- a/pipeline/config.json
+++ b/pipeline/config.json
@@ -14,7 +14,7 @@
         "n_steps" : 500,
         "low" : 0.0,
         "high" : null,
-        "scaling_factors" : [1.0]
+        "scaling_factors" : [0.0, 0.25, 0.5, 0.75, 1.0]
     },
     "simulations" : {
         "sampling" : {
@@ -23,8 +23,8 @@
             "n_samples" : 2000,
             "n_sampled_weeks" : 12
         },
-        "n_rep" : 50,
-        "i0" : [1000]
+        "n_rep" : 100,
+        "i0" : [100, 200, 400]
     },
     "renewal" : {
         "comments" : ["Infectious distribution is generation_interval.csv from https://github.com/cdcent/cfa-forecast-renewal-ww/tree/main/input/saved_pmfs as of 6096f8f0"],

--- a/pipeline/config.json
+++ b/pipeline/config.json
@@ -14,7 +14,7 @@
         "n_steps" : 500,
         "low" : 0.0,
         "high" : null,
-        "scaling_factors" : [0.0, 0.25, 0.5, 0.75, 1.0]
+        "scaling_factors" : [1.0]
     },
     "simulations" : {
         "sampling" : {
@@ -23,8 +23,8 @@
             "n_samples" : 2000,
             "n_sampled_weeks" : 12
         },
-        "n_rep" : 100,
-        "i0" : [1000, 2000, 4000]
+        "n_rep" : 3,
+        "i0" : [1000]
     },
     "renewal" : {
         "comments" : ["Infectious distribution is generation_interval.csv from https://github.com/cdcent/cfa-forecast-renewal-ww/tree/main/input/saved_pmfs as of 6096f8f0"],

--- a/pipeline/plot_coalescent_math.py
+++ b/pipeline/plot_coalescent_math.py
@@ -32,10 +32,10 @@ if __name__ == "__main__":
     unit_coal_rate = RenewalCoalescentModel.approx_coalescent_rate(
         prevalence,
         incidence,
-        np.repeat(1, incidence.shape[0] - 1),
+        np.repeat(1, incidence.shape[0]),
     )
 
-    fig, axs = plt.subplots(4, 1, figsize=(6, 12))
+    fig, axs = plt.subplots(3, 1, figsize=(6, 12))
 
     axs[0].scatter(np.arange(n_days), incidence[:n_days], marker=".")
     axs[0].set_ylabel("Incidence")

--- a/pipeline/plot_coalescent_math.py
+++ b/pipeline/plot_coalescent_math.py
@@ -7,24 +7,8 @@ from lag.models import RenewalCoalescentModel
 from pipeline.utils import parser, read_config
 
 
-def continuous_prevalence(tau, prevalence):
-    floor_tau = np.floor(tau).astype(int)
-    ceil_tau = np.where(
-        tau - floor_tau == 0.0, floor_tau + 1, np.ceil(tau)
-    ).astype(int)
-    delta_p = prevalence[ceil_tau] - prevalence[floor_tau]
-    return prevalence[floor_tau] + (tau - floor_tau) * delta_p
-
-
-def approx_sq_prevalence(tau, prevalence):
-    floor_tau = np.floor(tau).astype(int)
-    return RenewalCoalescentModel.approx_squared_prevalence(prevalence)[
-        floor_tau
-    ]
-
-
-def force_of_infection(tau, incidence):
-    return incidence[np.floor(tau).astype(int)]
+def stepwise_coal_rate(tau, pieces):
+    return pieces[np.floor(tau).astype(int)]
 
 
 if __name__ == "__main__":
@@ -40,17 +24,14 @@ if __name__ == "__main__":
 
     n_days = prevalence.shape[0] - 2
 
-    incidence = np.flip(incidence)[: prevalence.shape[0]]
+    incidence = np.flip(incidence[:-1])[: prevalence.shape[0]]
     prevalence = np.flip(prevalence)
 
     fine_time = np.linspace(0.0, n_days, 2500)
-    approx_sq_p = approx_sq_prevalence(fine_time, prevalence)
-    true_sq_p = continuous_prevalence(fine_time, prevalence) ** 2.0
-    error = (approx_sq_p - true_sq_p) / true_sq_p
 
     unit_coal_rate = RenewalCoalescentModel.approx_coalescent_rate(
-        RenewalCoalescentModel.approx_squared_prevalence(prevalence),
-        incidence[:-1],
+        prevalence,
+        incidence,
         np.repeat(1, incidence.shape[0] - 1),
     )
 
@@ -62,14 +43,11 @@ if __name__ == "__main__":
     axs[1].plot(np.arange(n_days), prevalence[:n_days])
     axs[1].set_ylabel("Prevalence")
 
-    axs[2].scatter(fine_time, error, marker=".")
-    axs[2].set_ylabel("Relative error of squared prevalence")
-
-    axs[3].scatter(
-        np.arange(unit_coal_rate.shape[0]), unit_coal_rate, marker="."
+    axs[2].plot(
+        fine_time, stepwise_coal_rate(fine_time, unit_coal_rate), marker="."
     )
-    axs[3].set_ylabel("Unit coalescent rate")
+    axs[2].set_ylabel("Unit coalescent rate")
 
-    axs[3].set_xlabel("Time before present (in days)")
+    axs[2].set_xlabel("Time before present (in days)")
 
     plt.savefig(args.outfile[0])

--- a/pipeline/plot_coalescent_rate.py
+++ b/pipeline/plot_coalescent_rate.py
@@ -59,10 +59,11 @@ if __name__ == "__main__":
 
     axs[3].scatter(
         np.arange(n_days - 1),
-        coalescent_counts.cumsum() / coalescent_counts.sum(),
+        1.0 - (coalescent_counts.cumsum() / coalescent_counts.sum()),
         marker=".",
     )
-    axs[3].set_ylabel("Mean cumulative proportion of coalescents")
+    axs[3].set_yscale("log")
+    axs[3].set_ylabel("Mean coalescent CCFD")
 
     axs[4].scatter(np.arange(n_days - 1), sampling_counts, marker=".")
     axs[4].set_ylabel("Mean daily samples")

--- a/pipeline/plot_coalescent_rate.py
+++ b/pipeline/plot_coalescent_rate.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
         marker=".",
     )
     axs[3].set_yscale("log")
-    axs[3].set_ylabel("Mean coalescent CCFD")
+    axs[3].set_ylabel("Mean coalescent CCDF")
 
     axs[4].scatter(np.arange(n_days - 1), sampling_counts, marker=".")
     axs[4].set_ylabel("Mean daily samples")

--- a/pipeline/simulate_data.py
+++ b/pipeline/simulate_data.py
@@ -47,17 +47,11 @@ if __name__ == "__main__":
         incidence = np.array(infections["incidence"])
         prevalence = np.array(infections["prevalence"])
 
-    approx_squared_prevalence = (
-        RenewalCoalescentModel.approx_squared_prevalence(prevalence)
-    )
-
     n_days = prevalence.shape[0] - 1
     rate_shift_times = np.arange(1, n_days)
 
-    backwards_incidence = np.flip(incidence)[:n_days]
-    backwards_approx_squared_prevalence = np.flip(approx_squared_prevalence)[
-        :n_days
-    ]
+    backwards_incidence = np.flip(incidence[:-1])[:n_days]
+    backwards_prevalence = np.flip(prevalence)[:n_days]
 
     with open(args.infile[1], "r") as file:
         lag_params = json.load(file)
@@ -74,7 +68,7 @@ if __name__ == "__main__":
         samp_times,
         rate_shift_times,
         backwards_incidence,
-        backwards_approx_squared_prevalence,
+        backwards_prevalence,
     )
     lags = lag_dist.draw(
         size=config["simulations"]["sampling"]["n_samples"],


### PR DESCRIPTION
This PR revists the theory behind the renewal coalescent with a particular emphasis on tracking incorrectness and incompatible assumptions. By examining the continuous-time renewal model more closely, it becomes apparent that the continuous functional forms of incidence, and thus prevalence, will in general be complex. As a result, this PR deprecates the attempt at a piecewise linear prevalence in favor of a more computationally convenient, piecewise constant approximation which doesn't require making additional layers of incorrect assumptions about incidence.

The viz and pipeline scripts are adjusted for compliance with the simpler approximation.